### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -24,7 +24,7 @@ library
     exposed-modules:  NoThunks.Class
 
     build-depends:    base       >= 4.12 && < 5
-                    , bytestring >= 0.10 && < 0.11
+                    , bytestring >= 0.10 && < 0.12
                     , containers >= 0.5  && < 0.7
                     , stm        >= 2.5  && < 2.6
                     , text       >= 1.2  && < 1.3


### PR DESCRIPTION
I'd appreciate a Hackage revision for this, because `nothunks` is used by Cabal tests and thus impedes migration to `bytestring-0.11` in GHC 9.2.