### PR TITLE
Fix compatibility with hedgehog 1.1.1+

### DIFF
--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -72,10 +72,10 @@ test-suite nothunks-test
                     , ghc-prim
 
                       -- Additional dependencies
-                    , hedgehog       >= 1.0 && < 1.1
+                    , hedgehog       >= 1.0 && < 1.2
                     , random         >= 1.1 && < 1.3
                     , tasty          >= 1.3 && < 1.5
-                    , tasty-hedgehog >= 1.0 && < 1.2
+                    , tasty-hedgehog >= 1.0 && < 1.3
 
     hs-source-dirs:   test
     default-language: Haskell2010

--- a/test/Test/NoThunks/Class.hs
+++ b/test/Test/NoThunks/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE DeriveGeneric       #-}
@@ -649,7 +650,11 @@ unsafeCheckNFAtomically expectedNF k = withTests 1 $ property $ k $ \x -> do
 expectFailure :: Property -> Property
 expectFailure p = withTests 1 $ property $ do
     report <- liftIO $ displayRegion $ \r ->
-                checkNamed r EnableColor (Just "EXPECTED FAILURE") p
+                checkNamed r EnableColor (Just "EXPECTED FAILURE")
+#if MIN_VERSION_hedgehog(1,1,1)
+                Nothing
+#endif
+                p
     case reportStatus report of
       Failed _ ->
         success


### PR DESCRIPTION
The incompatible change was introduced in https://github.com/hedgehogqa/haskell-hedgehog/pull/446

Verified to build fine and all tests pass.