### PR TITLE
nothunks-0.1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.10.7", "9.0.2", "9.2.4", "9.4.2", "9.6.1"]
+        ghc: ["8.10.7", "9.0.2", "9.2.5", "9.4.4", "9.6.1"]
     env:
       CONFIG: "--enable-tests"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.10.7", "9.0.2", "9.2.4", "9.4.2"]
+        ghc: ["8.10.7", "9.0.2", "9.2.4", "9.4.2", "9.6.1"]
     env:
       CONFIG: "--enable-tests"
     steps:
@@ -22,7 +22,7 @@ jobs:
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: 3.6.2.0
+          cabal-version: 3.8.1.0
       - run: cabal update
       - run: cabal freeze $CONFIG
       - uses: actions/cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for nothunks
 
+## 0.1.4 -- 2023-03-27
+
+* Made cabal flags manual.
+* Support ghc-9.2 to 9.6.
+* `ThunkInfo` is a newtype.
+
 ## 0.1.3 -- 2021-06-28
 
 * Fix tests on ghc-9.0.1

--- a/cabal.project
+++ b/cabal.project
@@ -5,3 +5,6 @@ package nothunks
 
 test-show-details: direct
 
+-- TODO: remove once hedgehog is compatible with ghc-9.6
+if impl(ghc >= 9.6)
+  allow-newer: hedgehog:template-haskell

--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -15,7 +15,7 @@ maintainer:         operations@iohk.io
 copyright:          2018-2021 IOHK
 category:           Development
 extra-source-files: CHANGELOG.md
-tested-with:        GHC== { 8.10.7, 9.0.2, 9.2.4, 9.4.2, 9.6.1 }
+tested-with:        GHC== { 8.10.7, 9.0.2, 9.2.5, 9.4.4, 9.6.1 }
 
 source-repository head
   type:     git

--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -24,14 +24,17 @@ source-repository head
 flag bytestring
   description: Provide instances for bytestring
   default: True
+  manual: True
 
 flag text
   description: Provide instances for text
   default: True
+  manual: True
 
 flag vector
   description: Provide instances for vector
   default: True
+  manual: True
 
 library
     exposed-modules:  NoThunks.Class

--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               nothunks
-version:            0.1.3
+version:            0.1.4
 synopsis:           Examine values for unexpected thunks
 description:        Long lived application data typically should not contain
                     any thunks. This library can be used to examine values for

--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -1,4 +1,4 @@
-cabal-version:      2.4
+cabal-version:      3.0
 name:               nothunks
 version:            0.1.3
 synopsis:           Examine values for unexpected thunks
@@ -15,7 +15,7 @@ maintainer:         operations@iohk.io
 copyright:          2018-2021 IOHK
 category:           Development
 extra-source-files: CHANGELOG.md
-tested-with:        GHC==8.10.7, GHC==9.0.2, GHC==9.2.4, GHC==9.4.2
+tested-with:        GHC== { 8.10.7, 9.0.2, 9.2.4, 9.4.2, 9.6.1 }
 
 source-repository head
   type:     git

--- a/src/NoThunks/Class.hs
+++ b/src/NoThunks/Class.hs
@@ -202,8 +202,10 @@ data ThunkInfo = ThunkInfo {
       -- > ---------------------------------------------------------------------
       -- > ["(,)"]                  the pair itself
       -- > ["Int","(,)"]            the Int in the pair
-      -- > ["[]","(,)"]             the [Int] in the pair
-      -- > ["Int","[]","(,)"]       an Int in the [Int] in the pair
+      -- > ["List","(,)"]           the [Int] in the pair
+      -- > ["Int","List","(,)"]     an Int in the [Int] in the pair
+      --
+      -- Note: prior to `ghc-9.6` a list was indicated by `[]`.
       thunkContext :: Context
     }
   deriving (Show)

--- a/src/NoThunks/Class.hs
+++ b/src/NoThunks/Class.hs
@@ -193,7 +193,7 @@ type Context = [String]
 -- to get source spans from closures. If we could take advantage of that, we
 -- could not only show the type of the unexpected thunk, but also where it got
 -- allocated.
-data ThunkInfo = ThunkInfo {
+newtype ThunkInfo = ThunkInfo {
       -- The @Context@ argument is intended to give a clue to add debugging.
       -- For example, suppose we have something of type @(Int, [Int])@. The
       -- various contexts we might get are

--- a/test/Test/NoThunks/Class.hs
+++ b/test/Test/NoThunks/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE DeriveGeneric       #-}
@@ -241,7 +242,11 @@ instance FromModel a => FromModel [a] where
       ListNil        -> IsNF
       ListCons x xs' -> constrNF [modelIsNF ctxt' x, modelIsNF ctxt xs']
     where
+#if MIN_VERSION_GLASGOW_HASKELL(9,6,0,0)
+      ctxt' = "List" : ctxt
+#else
       ctxt' = "[]" : ctxt
+#endif
 
   fromModel (ListThunk xs)  k = fromModel xs $ \xs' -> k (if ack 3 3 > 0 then xs' else xs')
   fromModel ListNil         k = k []


### PR DESCRIPTION
- Make cabal flags manual
- Build with `ghc-9.6`
- Updated ghc matrix
- Turned ThunkInfo into a newtype
- Version 0.1.4
