### PR TITLE
Use info tables to get context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+* Use `whereFrom` to get source information, which is avialable when the source
+  is compiled with `GHC-9.2` (or newer) and with `-finfo-table-map` (and even
+  more accurate when `-fdistinct-constructor-table` is passed).
 * `NoThunks` instance for `Data.Tuple.Solo`.
 * `NoThunks` instances for `Data.Semigroup` and `Data.Monoid` newtype wrappers.
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ See my presentation
 [MuniHac 2020: Being lazy without being bloated](https://www.youtube.com/watch?v=7t6wt7ByBWg)
 for an overview, motivating the library and explaining how it is intended to be
 used and how it works internally.
+
+
+`nothunks` will try to get source information from info tables. For that one
+needs to use `GHC` newer than `9.4` and compile the code with
+`-finfo-table-map`.  More precise information will be available if
+`-fdistinct-constructor-table` flag is used as well.  We don't support this
+feature in `GHC-9.2` (although an earlier version of `whereFrom`
+is available in `base`).

--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -41,7 +41,7 @@ library
     exposed-modules:  NoThunks.Class
 
     build-depends:    base       >= 4.12 && < 5
-                    , containers >= 0.5  && < 0.7
+                    , containers >= 0.5  && < 0.8
                     , stm        >= 2.5  && < 2.6
                     , time       >= 1.5  && < 1.13
 

--- a/src/NoThunks/Class.hs
+++ b/src/NoThunks/Class.hs
@@ -536,14 +536,14 @@ deriving via (f a) instance NoThunks (f a) => NoThunks (Monoid.Ap f a)
   Solo
 -------------------------------------------------------------------------------}
 
-#if MIN_VERSION_base(4,16,0)
+#if MIN_VERSION_base(4,18,0)
+-- GHC-9.6 and newer
+instance NoThunks a => NoThunks (Solo a) where
+    wNoThunks ctx (MkSolo a) = wNoThunks ("Solo" : ctx) a
+#elif MIN_VERSION_base(4,16,0)
 -- GHC-9.2
 instance NoThunks a => NoThunks (Solo a) where
     wNoThunks ctx (Solo a) = wNoThunks ("Solo" : ctx) a
-#elif MIN_VERSION_base(4,17,0)
--- GHC-9.4 and newer
-instance NoThunks a => NoThunks (Solo a) where
-    wNoThunks ctx (MkSolo a) = wNoThunks ("Solo" : ctx) a
 #endif
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
Since `GHC-9.4` we can use `GHC.InfoProv.whereFrom` to get source
information of terms.  It is actually available in `GHC-9.2` too, but we don't support the earlier version of it.
