### PR TITLE
Use wherefrom-compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ used and how it works internally.
 
 
 `nothunks` will try to get source information from info tables. For that one
-needs to use `GHC` newer than `9.4` and compile the code with
+needs to use `GHC` `9.2` or newer and compile the code with
 `-finfo-table-map`.  More precise information will be available if
-`-fdistinct-constructor-tables` flag is used as well.  We don't support this
-feature in `GHC-9.2` (although an earlier version of `whereFrom`
-is available in `base`).
+`-fdistinct-constructor-tables` flag is used as well.  

--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -48,6 +48,8 @@ library
                       -- Whatever is bundled with ghc
                     , ghc-heap
 
+    if impl(ghc >= 9.2)
+      build-depends:  wherefrom-compat >= 0.1.1.0 && < 0.2.0.0
     if flag(bytestring)
       build-depends:  bytestring >= 0.10 && < 0.13
     if flag(text)

--- a/src/NoThunks/Class.hs
+++ b/src/NoThunks/Class.hs
@@ -71,8 +71,8 @@ import GHC.Stack
 import Numeric.Natural
 #endif
 
-#if MIN_VERSION_base(4,18,0)
-import GHC.InfoProv
+#if MIN_VERSION_base(4,16,0)
+import GHC.InfoProv.Compat
 #endif
 
 import qualified Control.Concurrent.MVar       as MVar
@@ -231,7 +231,7 @@ newtype ThunkInfo = ThunkInfo { thunkInfo  :: Either Context Info }
   deriving Show
 
 getThunkInfo :: Context -> a -> IO ThunkInfo
-#if MIN_VERSION_base(4,18,0)
+#if MIN_VERSION_base(4,16,0)
 getThunkInfo ctxt a = ThunkInfo . maybe (Left ctxt) (Right . fmt) <$> whereFrom a
   where
     fmt :: InfoProv -> Info


### PR DESCRIPTION
This provides a compatibility shim around the wherefrom function allowing a stable interface to be used for more versions of GHC.

In particular it should insulate users of the library from future breaking changes.

A nice upside is that it allows using `whereFrom` when it was first introduced rather than when it moved to `GHC.InfoProv`.

I've added a cabal flag, so the solver can still pick versions of `base` before `whereFrom` existed