### PR TITLE
Report _both_ context _and_ info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for nothunks
 
+## 0.3.0 -- not yet released
+
+* Include _both_ `Context` _and_ `Info` in `ThunkInfo` (#54)
+
 ## 0.2.1.0 -- 2024-02-06
 
 * Exported `mkThunkInfo`.

--- a/test/Test/NoThunks/Class.hs
+++ b/test/Test/NoThunks/Class.hs
@@ -107,7 +107,7 @@ agreeOnNF mThunk mCtxt = isNothing mThunk == isNothing mCtxt
 -- | Check whether the model and the implementation agree on whether the value
 -- is in NF, and if not, what the context of the thunk is.
 agreeOnContext :: Maybe ThunkInfo -> Maybe [String] -> Bool
-agreeOnContext mThunk mCtxt = (thunkInfo <$> mThunk) == (Left <$> mCtxt)
+agreeOnContext mThunk mCtxt = (thunkContext <$> mThunk) == mCtxt
 
 {-------------------------------------------------------------------------------
   Infrastructure


### PR DESCRIPTION
#47 changed the `ThunkInfo` type to

```haskell
newtype ThunkInfo = ThunkInfo { thunkInfo  :: Either Context Info }
```

While having support for `Info` is fantastic and a great addition, in some cases having _both_ pieces of information makes debugging a bit easier. I am not entirely sure why `Either` was chosen here instead of a tuple, perhaps there was a good reason; if so, feel free to disregard this PR. However, in this PR we change this to

```haskell
newtype ThunkInfo = ThunkInfo { thunkInfo  :: (Context, Maybe Info) }
```