### PR TITLE
Support wherefrom-compat-0.2

### DIFF
--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -49,7 +49,7 @@ library
                     , ghc-heap
 
     if impl(ghc >= 9.2)
-      build-depends:  wherefrom-compat ^>= 0.1.1
+      build-depends:  wherefrom-compat >= 0.1.1 && < 0.3
 
     if flag(bytestring)
       build-depends:  bytestring >= 0.10 && < 0.13


### PR DESCRIPTION
The new major version corresponds to the version of the API that comes with base-4.20. No changes are needed don the nothunks side because it just depends on instances