### PR TITLE
Broader support range for wherefrom-compat

### DIFF
--- a/nothunks.cabal
+++ b/nothunks.cabal
@@ -49,7 +49,7 @@ library
                     , ghc-heap
 
     if impl(ghc >= 9.2)
-      build-depends:  wherefrom-compat ^>= 0.2
+      build-depends:  wherefrom-compat >= 0.1.1 && < 0.3
 
     if flag(bytestring)
       build-depends:  bytestring >= 0.10 && < 0.13


### PR DESCRIPTION
Supporting multiple major versions of wherefrom-compat allows end-users to pick which version of the interface they would like to use giving more flexibility